### PR TITLE
Added an IAM policy snippet that allows recipient access to only a specific S3 bucket

### DIFF
--- a/IAM/S3.md
+++ b/IAM/S3.md
@@ -29,6 +29,39 @@ IAM policy to block all access to S3 unless it originates from the VPC/VPCe in t
 }
 ```
 
+IAM policy that allows the recipient access to a specific bucket. Works for Cloudberry Explorer and may be useful for other similar tools and backup software. Replace ${bucket-name} with the actual name of the bucket.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": "arn:aws:s3:::${bucket-name}",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": "arn:aws:s3:::${bucket-name}/*",
+            "Effect": "Allow"
+        }
+    ]
+}
+```
+
+
 Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
IAM policy that allows the recipient full access to a specific bucket. Works for Cloudberry Explorer and may be useful for other similar tools and backup software. Replace ${bucket-name} with the actual name of the bucket.

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "s3:ListAllMyBuckets"
            ],
            "Resource": "arn:aws:s3:::*",
            "Effect": "Allow"
        },
        {
            "Action": [
                "s3:ListBucket",
                "s3:GetBucketLocation"
            ],
            "Resource": "arn:aws:s3:::${bucket-name}",
            "Effect": "Allow"
        },
        {
            "Action": [
                "s3:*"
            ],
            "Resource": "arn:aws:s3:::${bucket-name}/*",
            "Effect": "Allow"
        }
    ]
}
```